### PR TITLE
Inline dashboard, getting rid of dashboard template

### DIFF
--- a/DASHBOARD_UI_GUIDE.md
+++ b/DASHBOARD_UI_GUIDE.md
@@ -1,0 +1,126 @@
+# Creating the Ground Station Dashboard via the QuickSight UI
+
+This guide walks through manually creating the Ground Station contacts dashboard in Amazon QuickSight. Use this if the CloudFormation stack deploys everything except the dashboard itself (i.e., the DataSource and DataSet already exist).
+
+## Prerequisites
+
+- Stack 1 and Stack 2 (without the GSDashboard resource) have been deployed successfully
+- The following resources exist in QuickSight:
+  - DataSource: **GSDashboardQSDataSource**
+  - DataSet: **GSDashboardQSDataset**
+- You have QuickSight author or admin permissions
+
+## Step 1: Create a new analysis
+
+1. Open the QuickSight console
+2. Click **Analyses** in the left navigation
+3. Click **New analysis**
+4. Select the **GSDashboardQSDataset** dataset
+5. Click **Use in analysis**
+6. Select **Interactive sheet** when prompted
+
+## Step 2: Rename the sheet
+
+1. Double-click the sheet tab at the top (default name is "Sheet 1")
+2. Rename it to **Contacts Overview**
+
+## Step 3: Add the contacts table
+
+1. Click **Add** → **Add visual**
+2. Select **Table** as the visual type
+3. In the **Field wells** panel, drag the following fields into **Group by** (in this order):
+   - `contactid`
+   - `groundstation`
+   - `contactstatus`
+   - `satellitearn`
+   - `missionprofilearn`
+   - `starttime`
+   - `endtime`
+   - `curcontactid`
+   - `tags`
+   - `region`
+4. Click the title area and set it to: **AWS Ground Station contacts information and mapping to Cost and Usage Report fields**
+
+### Configure the date fields
+
+5. Click the `starttime` field in the field wells → change aggregation to **Second**
+6. Click the `endtime` field in the field wells → change aggregation to **Second**
+
+### Resize the table
+
+7. Drag the edges of the table visual to make it taller and wider so more rows and columns are visible
+8. Column widths can be adjusted by dragging the column borders in the table header if needed
+
+### Configure table styling
+
+9. Hover over the table visual and click the pencil icon ("Format visual") in the top right corner of the visual to adjust properties like header style, cell height, text wrapping, etc.
+
+## Step 4: Add the "Contacts by Status" pie chart
+
+1. Click **Add** → **Add visual**
+2. Select **Pie chart** as the visual type
+3. In the field wells:
+   - **Group/Color**: drag `contactstatus`
+   - **Value**: drag `contactid` (set aggregation to Count)
+4. Click the title area and set it to: **Count of contacts by contact status**
+5. Hover over the pie chart visual and click the pencil icon in the top right corner of the visual → configure:
+   - **Data labels**: turn on, enable **Show metric**
+
+## Step 5: Add the "Contacts by Ground Station" pie chart
+
+1. Click **Add** → **Add visual**
+2. Select **Pie chart** as the visual type
+3. In the field wells:
+   - **Group/Color**: drag `groundstation`
+   - **Value**: drag `contactid` (set aggregation to Count)
+4. Click the title area and set it to: **Count of contacts by Ground Station**
+5. Hover over the pie chart visual and click the pencil icon in the top right corner of the visual → configure:
+   - **Data labels**: turn on, enable **Show metric**
+
+## Step 6: Arrange the layout
+
+Drag and resize the visuals so they match this layout:
+
+```
++--------------------------------------------------+
+|                                                  |
+|              Contacts Table (full width)         |
+|                                                  |
++------------------------+-------------------------+
+|                        |                         |
+|  Status Pie Chart      |  Ground Station Pie     |
+|  (left half)           |  Chart (right half)     |
+|                        |                         |
++------------------------+-------------------------+
+```
+
+- The table should span the full width of the sheet
+- The two pie charts should be side by side below the table, each taking half the width
+
+## Step 7: Add filters
+
+First, click on the **Contacts Table** visual to select it. Then add the following filters by clicking the **Filter** icon (funnel icon) in the top panel → **Add filter**:
+
+| Filter | Field |
+|--------|-------|
+| contactid | `contactid` |
+| groundstation | `groundstation` |
+| contactstatus | `contactstatus` |
+| satellitearn | `satellitearn` |
+| missionprofilearn | `missionprofilearn` |
+| starttime | `starttime` |
+| endtime | `endtime` |
+| curcontactid | `curcontactid` |
+| tags | `tags` |
+| region | `region` |
+
+For each filter:
+1. Click **Add filter** → select the field
+2. Click the three dots on the filter → **Manage control** → **Move to top of sheet**
+
+## Step 8: Publish as a dashboard
+
+1. Click **Share** in the top right
+2. Click **Publish dashboard**
+3. Name it **GSDashboard**
+4. Click **Publish dashboard**

--- a/DASHBOARD_UI_GUIDE.md
+++ b/DASHBOARD_UI_GUIDE.md
@@ -1,6 +1,6 @@
 # Creating the Ground Station Dashboard via the QuickSight UI
 
-This guide walks through manually creating the Ground Station contacts dashboard in Amazon QuickSight. Use this if the CloudFormation stack deploys everything except the dashboard itself (i.e., the DataSource and DataSet already exist).
+This guide walks through manually creating the Ground Station contacts dashboard in Amazon QuickSight. Use this if you set the `DeployDashboard` parameter to `no` when deploying the `gsdashboard-part2.yml` CloudFormation stack. In that case, the DataSource and DataSet are still created automatically — only the dashboard itself is skipped.
 
 ## Prerequisites
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -217,6 +217,7 @@ arn:aws:quicksight:us-east-1:123456789012:user/default/admin/doe-john
     * **GStable**: Name of the table storing Ground Station contacts data (see point 2 above).
     * **GsContactPart1StackName**: Name of the CloudFormation stack created in [2. Solution back-end deployment](./DEPLOYMENT.md#2-solution-back-end-deployment).
     * **ApplicationTag**: Tag value for the tag that is added to the created resources. Tag key will be 'application'.
+    * **DeployDashboard**: Whether to deploy the pre-built QuickSight dashboard. Set to `yes` (default) to deploy the dashboard automatically, or `no` to skip dashboard creation and build it manually using the [Dashboard UI Guide](./DASHBOARD_UI_GUIDE.md). The DataSource and DataSet are always created regardless of this setting.
 
 10. Choose **Next**.
 

--- a/cfn/gsdashboard-part2.yml
+++ b/cfn/gsdashboard-part2.yml
@@ -852,11 +852,606 @@ Resources:
             - "quicksight:DescribeDashboardPermissions"
             - "quicksight:UpdateDashboardPublishedVersion"
           Principal: !Sub "${AmazonQuickSightPrincipalArn}"
-      SourceEntity:
-        SourceTemplate:
-          Arn: "arn:aws:quicksight:us-east-2:421660149373:template/gsdashboard/version/5"
-          DataSetReferences:
-            - DataSetArn: !GetAtt
-                - GSDashboardQSDataSet
-                - Arn
-              DataSetPlaceholder: "dataset1"
+      DashboardPublishOptions:
+        AdHocFilteringOption:
+          AvailabilityStatus: DISABLED
+        ExportToCSVOption:
+          AvailabilityStatus: ENABLED
+        SheetControlsOption:
+          VisibilityState: COLLAPSED
+        SheetLayoutElementMaximizationOption:
+          AvailabilityStatus: ENABLED
+        VisualMenuOption:
+          AvailabilityStatus: ENABLED
+        VisualAxisSortOption:
+          AvailabilityStatus: ENABLED
+        ExportWithHiddenFieldsOption:
+          AvailabilityStatus: DISABLED
+        DataPointDrillUpDownOption:
+          AvailabilityStatus: ENABLED
+        DataPointMenuLabelOption:
+          AvailabilityStatus: ENABLED
+        DataPointTooltipOption:
+          AvailabilityStatus: ENABLED
+      ValidationStrategy:
+        Mode: LENIENT
+      Definition:
+        DataSetIdentifierDeclarations:
+          - Identifier: "gsdashboardview"
+            DataSetArn: !GetAtt GSDashboardQSDataSet.Arn
+
+        AnalysisDefaults:
+          DefaultNewSheetConfiguration:
+            InteractiveLayoutConfiguration:
+              Grid:
+                CanvasSizeOptions:
+                  ScreenCanvasSizeOptions:
+                    ResizeOption: FIXED
+                    OptimizedViewPortWidth: "1600px"
+            SheetContentType: INTERACTIVE
+        FilterGroups:
+          - FilterGroupId: fg-contactid
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-contactid
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: contactid
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-groundstation
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-groundstation
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: groundstation
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-contactstatus
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-contactstatus
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: contactstatus
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-satellitearn
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-satellitearn
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: satellitearn
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-missionprofilearn
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-missionprofilearn
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: missionprofilearn
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-starttime
+            Filters:
+              - TimeRangeFilter:
+                  FilterId: filter-starttime
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: starttime
+                  NullOption: NON_NULLS_ONLY
+                  TimeGranularity: DAY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-endtime
+            Filters:
+              - TimeRangeFilter:
+                  FilterId: filter-endtime
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: endtime
+                  NullOption: NON_NULLS_ONLY
+                  TimeGranularity: DAY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-curcontactid
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-curcontactid
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: curcontactid
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-tags
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-tags
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: tags
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+          - FilterGroupId: fg-region
+            Filters:
+              - CategoryFilter:
+                  FilterId: filter-region
+                  Column:
+                    DataSetIdentifier: gsdashboardview
+                    ColumnName: region
+                  Configuration:
+                    FilterListConfiguration:
+                      MatchOperator: CONTAINS
+                      SelectAllOptions: FILTER_ALL_VALUES
+                      NullOption: NON_NULLS_ONLY
+            ScopeConfiguration:
+              SelectedSheets:
+                SheetVisualScopingConfigurations:
+                  - SheetId: ContactsOverview
+                    Scope: SELECTED_VISUALS
+                    VisualIds:
+                      - ContactsTable
+            Status: ENABLED
+            CrossDataset: SINGLE_DATASET
+
+        Sheets:
+          - SheetId: ContactsOverview
+            Name: "Contacts Overview"
+            ContentType: INTERACTIVE
+            FilterControls:
+              - DateTimePicker:
+                  FilterControlId: fc-starttime
+                  Title: "starttime between"
+                  SourceFilterId: filter-starttime
+                  Type: DATE_RANGE
+              - DateTimePicker:
+                  FilterControlId: fc-endtime
+                  Title: "endtime between"
+                  SourceFilterId: filter-endtime
+                  Type: DATE_RANGE
+              - Dropdown:
+                  FilterControlId: fc-contactid
+                  Title: "contactid equals"
+                  SourceFilterId: filter-contactid
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-groundstation
+                  Title: "groundstation equals"
+                  SourceFilterId: filter-groundstation
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-contactstatus
+                  Title: "contactstatus equals"
+                  SourceFilterId: filter-contactstatus
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-satellitearn
+                  Title: "satellitearn equals"
+                  SourceFilterId: filter-satellitearn
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-missionprofilearn
+                  Title: "missionprofilearn equals"
+                  SourceFilterId: filter-missionprofilearn
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-curcontactid
+                  Title: "curcontactid equals"
+                  SourceFilterId: filter-curcontactid
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-tags
+                  Title: "tags equals"
+                  SourceFilterId: filter-tags
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+              - Dropdown:
+                  FilterControlId: fc-region
+                  Title: "region equals"
+                  SourceFilterId: filter-region
+                  DisplayOptions:
+                    SelectAllOptions:
+                      Visibility: VISIBLE
+                  Type: MULTI_SELECT
+            Visuals:
+              - TableVisual:
+                  VisualId: ContactsTable
+                  Title:
+                    Visibility: VISIBLE
+                    FormatText:
+                      RichText: "<visual-title>AWS Ground Station contacts information and mapping to Cost and Usage Report fields</visual-title>"
+                  Subtitle:
+                    Visibility: VISIBLE
+                  ChartConfiguration:
+                    FieldWells:
+                      TableAggregatedFieldWells:
+                        GroupBy:
+                          - CategoricalDimensionField:
+                              FieldId: f-contactid
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: contactid
+                          - CategoricalDimensionField:
+                              FieldId: f-groundstation
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: groundstation
+                          - CategoricalDimensionField:
+                              FieldId: f-contactstatus
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: contactstatus
+                          - CategoricalDimensionField:
+                              FieldId: f-satellitearn
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: satellitearn
+                          - CategoricalDimensionField:
+                              FieldId: f-missionprofilearn
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: missionprofilearn
+                          - DateDimensionField:
+                              FieldId: f-starttime
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: starttime
+                              DateGranularity: SECOND
+                              FormatConfiguration:
+                                DateTimeFormat: "YYYY/MM/DD, hh:mm:ss"
+                                NullValueFormatConfiguration:
+                                  NullString: "null"
+                          - DateDimensionField:
+                              FieldId: f-endtime
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: endtime
+                              DateGranularity: SECOND
+                              FormatConfiguration:
+                                DateTimeFormat: "YYYY/MM/DD, hh:mm:ss"
+                                NullValueFormatConfiguration:
+                                  NullString: "null"
+                          - CategoricalDimensionField:
+                              FieldId: f-curcontactid
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: curcontactid
+                          - CategoricalDimensionField:
+                              FieldId: f-tags
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: tags
+                          - CategoricalDimensionField:
+                              FieldId: f-region
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: region
+                        Values: []
+                    SortConfiguration: {}
+                    TableOptions:
+                      HeaderStyle:
+                        TextWrap: WRAP
+                        Height: 25
+                      CellStyle:
+                        Height: 26
+                    FieldOptions:
+                      SelectedFieldOptions:
+                        - FieldId: f-satellitearn
+                          Width: "353px"
+                        - FieldId: f-missionprofilearn
+                          Width: "199px"
+                        - FieldId: f-starttime
+                          Width: "247px"
+                      Order:
+                        - f-contactid
+                        - f-groundstation
+                        - f-contactstatus
+                        - f-satellitearn
+                        - f-missionprofilearn
+                        - f-starttime
+                        - f-endtime
+                        - f-curcontactid
+                        - f-tags
+                        - f-region
+                  Actions: []
+              - PieChartVisual:
+                  VisualId: StatusPieChart
+                  Title:
+                    Visibility: VISIBLE
+                    FormatText:
+                      RichText: "<visual-title>Count of contacts by contact status</visual-title>"
+                  Subtitle:
+                    Visibility: VISIBLE
+                  ChartConfiguration:
+                    FieldWells:
+                      PieChartAggregatedFieldWells:
+                        Category:
+                          - CategoricalDimensionField:
+                              FieldId: pie-status-cat
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: contactstatus
+                        Values:
+                          - CategoricalMeasureField:
+                              FieldId: pie-status-val
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: contactstatus
+                              AggregationFunction: COUNT
+                    SortConfiguration:
+                      CategorySort:
+                        - FieldSort:
+                            FieldId: pie-status-val
+                            Direction: DESC
+                      CategoryItemsLimit:
+                        OtherCategories: INCLUDE
+                      SmallMultiplesLimitConfiguration:
+                        OtherCategories: INCLUDE
+                    DonutOptions:
+                      ArcOptions:
+                        ArcThickness: WHOLE
+                    DataLabels:
+                      Visibility: VISIBLE
+                      MeasureLabelVisibility: VISIBLE
+                      Overlap: DISABLE_OVERLAP
+                    Tooltip:
+                      TooltipVisibility: VISIBLE
+                      SelectedTooltipType: DETAILED
+                      FieldBasedTooltip:
+                        AggregationVisibility: HIDDEN
+                        TooltipTitleType: PRIMARY_VALUE
+                        TooltipFields:
+                          - FieldTooltipItem:
+                              FieldId: pie-status-val
+                              Visibility: VISIBLE
+                          - FieldTooltipItem:
+                              FieldId: pie-status-cat
+                              Visibility: VISIBLE
+                  Actions: []
+                  ColumnHierarchies: []
+              - PieChartVisual:
+                  VisualId: GroundStationPieChart
+                  Title:
+                    Visibility: VISIBLE
+                    FormatText:
+                      RichText: "<visual-title>Count of contacts by Ground Station</visual-title>"
+                  Subtitle:
+                    Visibility: VISIBLE
+                  ChartConfiguration:
+                    FieldWells:
+                      PieChartAggregatedFieldWells:
+                        Category:
+                          - CategoricalDimensionField:
+                              FieldId: pie-gs-cat
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: groundstation
+                        Values:
+                          - CategoricalMeasureField:
+                              FieldId: pie-gs-val
+                              Column:
+                                DataSetIdentifier: gsdashboardview
+                                ColumnName: groundstation
+                              AggregationFunction: COUNT
+                    SortConfiguration:
+                      CategorySort:
+                        - FieldSort:
+                            FieldId: pie-gs-val
+                            Direction: DESC
+                      CategoryItemsLimit:
+                        OtherCategories: INCLUDE
+                      SmallMultiplesLimitConfiguration:
+                        OtherCategories: INCLUDE
+                    DonutOptions:
+                      ArcOptions:
+                        ArcThickness: WHOLE
+                    DataLabels:
+                      Visibility: VISIBLE
+                      MeasureLabelVisibility: VISIBLE
+                      Overlap: DISABLE_OVERLAP
+                    Tooltip:
+                      TooltipVisibility: VISIBLE
+                      SelectedTooltipType: DETAILED
+                      FieldBasedTooltip:
+                        AggregationVisibility: HIDDEN
+                        TooltipTitleType: PRIMARY_VALUE
+                        TooltipFields:
+                          - FieldTooltipItem:
+                              FieldId: pie-gs-cat
+                              Visibility: VISIBLE
+                          - FieldTooltipItem:
+                              FieldId: pie-gs-val
+                              Visibility: VISIBLE
+                  Actions: []
+                  ColumnHierarchies: []
+            Layouts:
+              - Configuration:
+                  GridLayout:
+                    Elements:
+                      - ElementId: ContactsTable
+                        ElementType: VISUAL
+                        ColumnIndex: 0
+                        ColumnSpan: 36
+                        RowIndex: 0
+                        RowSpan: 12
+                      - ElementId: StatusPieChart
+                        ElementType: VISUAL
+                        ColumnIndex: 0
+                        ColumnSpan: 18
+                        RowIndex: 12
+                        RowSpan: 12
+                      - ElementId: GroundStationPieChart
+                        ElementType: VISUAL
+                        ColumnIndex: 18
+                        ColumnSpan: 18
+                        RowIndex: 12
+                        RowSpan: 12
+                    CanvasSizeOptions:
+                      ScreenCanvasSizeOptions:
+                        ResizeOption: FIXED
+                        OptimizedViewPortWidth: "1600px"
+            SheetControlLayouts:
+              - Configuration:
+                  GridLayout:
+                    Elements:
+                      - ElementId: fc-contactid
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-groundstation
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-contactstatus
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-satellitearn
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-missionprofilearn
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-starttime
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-endtime
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-curcontactid
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-tags
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1
+                      - ElementId: fc-region
+                        ElementType: FILTER_CONTROL
+                        ColumnSpan: 2
+                        RowSpan: 1

--- a/cfn/gsdashboard-part2.yml
+++ b/cfn/gsdashboard-part2.yml
@@ -45,6 +45,17 @@ Parameters:
     Default: 'gs-contact-reporting'
     AllowedPattern: "^[a-z0-9-]+$"
 
+  DeployDashboard:
+    Type: String
+    Description: Whether to deploy the QuickSight dashboard. Set to 'no' if you want to create the dashboard manually using the Dashboard UI Guide.
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+
+Conditions:
+  ShouldDeployDashboard: !Equals [!Ref DeployDashboard, 'yes']
+
 Resources:
 
 ###########################################################################
@@ -833,6 +844,7 @@ Resources:
             
   GSDashboard:
     Type: AWS::QuickSight::Dashboard
+    Condition: ShouldDeployDashboard
     DependsOn: GSDashboardQSDataSet
     Properties:
       Tags:


### PR DESCRIPTION
Defines the QuickSight dashboard directly in the CloudFormation template rather than referencing an external template, avoiding issues with template permissions and stale references.

A new DeployDashboard parameter (yes/no) allows users to skip the dashboard resource while still deploying the DataSource and DataSet. Users who opt out can follow the Dashboard UI Guide to create the dashboard manually in QuickSight.